### PR TITLE
CEXT-5293: Env-specifig region options for db

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@adobe/aio-lib-core-config": "^5",
     "@adobe/aio-lib-core-logging": "^3",
     "@adobe/aio-lib-db": "git+https://github.com/adobe/aio-lib-db.git",
+    "@adobe/aio-lib-env": "^3.0.1",
     "@adobe/aio-lib-state": "^5",
     "@inquirer/prompts": "^5",
     "@oclif/core": "^4",
@@ -80,6 +81,8 @@
     "collectCoverage": true,
     "testEnvironment": "node",
     "transform": {},
-    "setupFiles": ["<rootDir>/test/jest.env.js"]
+    "setupFiles": [
+      "<rootDir>/test/jest.env.js"
+    ]
   }
 }

--- a/src/DBBaseCommand.js
+++ b/src/DBBaseCommand.js
@@ -15,6 +15,7 @@ import config from '@adobe/aio-lib-core-config'
 import { CONFIG_RUNTIME_AUTH, CONFIG_RUNTIME_NAMESPACE } from './constants/global.js'
 import { AVAILABLE_REGIONS, CONFIG_DB_ENDPOINT, CONFIG_DB_REGION, DEFAULT_REGION } from './constants/db.js'
 import { Flags } from '@oclif/core'
+import { getCliEnv } from '@adobe/aio-lib-env'
 
 export class DBBaseCommand extends BaseCommand {
   async init () {
@@ -31,13 +32,20 @@ export class DBBaseCommand extends BaseCommand {
    */
   async initializeDBClient () {
     try {
+      const region = this.flags?.region || config.get(CONFIG_DB_REGION) || DEFAULT_REGION
       // Get database configuration
       const dbConfig = {
         ow: {
           namespace: config.get(CONFIG_RUNTIME_NAMESPACE),
           auth: config.get(CONFIG_RUNTIME_AUTH)
         },
-        region: this.flags?.region || config.get(CONFIG_DB_REGION) || DEFAULT_REGION
+        region
+      }
+
+      // Validate region based on environment
+      const allowedRegions = AVAILABLE_REGIONS[getCliEnv()] || AVAILABLE_REGIONS.prod
+      if (!allowedRegions.includes(region)) {
+        this.error(`Invalid region '${region}'. Valid options: ${allowedRegions.join(', ')}`)
       }
 
       // Validate required configuration
@@ -96,9 +104,8 @@ DBBaseCommand.flags = {
     helpGroup: 'GLOBAL'
   },
   region: Flags.string({
-    description: `Database region. Defaults to 'AIO_DB_REGION' environment variable or '${DEFAULT_REGION}' if neither is set.`,
+    description: `Database region. Defaults to 'AIO_DB_REGION' environment variable or '${DEFAULT_REGION}' if neither is set.\n<options: ${AVAILABLE_REGIONS.prod.join('|')}>`,
     required: false,
-    options: AVAILABLE_REGIONS,
     helpGroup: 'GLOBAL'
     // Don't set default here to let it load from the environment var if not passed as a flag
   })

--- a/src/constants/db.js
+++ b/src/constants/db.js
@@ -24,6 +24,9 @@ export const DB_STATUS = {
 // Region constants for db are separate from state in case they diverge in the future
 export const CONFIG_DB_REGION = 'db.region'
 export const DEFAULT_REGION = 'amer'
-export const AVAILABLE_REGIONS = ['amer', 'emea', 'apac']
+export const AVAILABLE_REGIONS = {
+  prod: ['amer', 'emea', 'apac'],
+  stage: ['amer', 'amer2']
+}
 
 export const CONFIG_DB_ENDPOINT = 'db.endpoint'

--- a/test/DBBaseCommand.test.js
+++ b/test/DBBaseCommand.test.js
@@ -27,7 +27,6 @@ describe('prototype', () => {
   test('flags', () => {
     expect(Object.keys(DBBaseCommand.flags).sort()).toEqual(['json', 'region'])
     expect(DBBaseCommand.enableJsonFlag).toEqual(true)
-    expect(DBBaseCommand.flags.region.options).toEqual(AVAILABLE_REGIONS)
   })
   test('getServiceName', () => {
     const command = new DBBaseCommand([])
@@ -73,6 +72,58 @@ describe('init', () => {
     await command.init()
 
     expect(command.dbConfig.region).toBe(DEFAULT_REGION)
+  })
+
+  test('initialization with environment-specific region', async () => {
+    const env = process.env.AIO_CLI_ENV
+    try {
+      process.env.AIO_CLI_ENV = 'stage'
+      command.argv = ['--region', 'amer2']
+      await expect(command.init()).resolves.not.toThrow()
+      expect(command.dbConfig.region).toBe('amer2')
+
+      process.env.AIO_CLI_ENV = 'prod'
+      command.argv = ['--region', 'emea']
+      await expect(command.init()).resolves.not.toThrow()
+      expect(command.dbConfig.region).toBe('emea')
+
+      // default to prod if env is not recognized or not set
+      process.env.AIO_CLI_ENV = 'test'
+      command.argv = ['--region', 'emea']
+      await expect(command.init()).resolves.not.toThrow()
+      expect(command.dbConfig.region).toBe('emea')
+
+      delete process.env.AIO_CLI_ENV
+      command.argv = ['--region', 'emea']
+      await expect(command.init()).resolves.not.toThrow()
+      expect(command.dbConfig.region).toBe('emea')
+    } finally {
+      process.env.AIO_CLI_ENV = env
+    }
+  })
+
+  test('initialization with environment-specific region fails in other environment', async () => {
+    const env = process.env.AIO_CLI_ENV
+    try {
+      process.env.AIO_CLI_ENV = 'stage'
+      command.argv = ['--region', 'emea']
+      await expect(command.init()).rejects.toThrow(`Valid options: ${AVAILABLE_REGIONS.stage.join(', ')}`)
+
+      process.env.AIO_CLI_ENV = 'prod'
+      command.argv = ['--region', 'amer2']
+      await expect(command.init()).rejects.toThrow(`Valid options: ${AVAILABLE_REGIONS.prod.join(', ')}`)
+
+      // default to prod if env is not recognized or not set
+      process.env.AIO_CLI_ENV = 'test'
+      command.argv = ['--region', 'amer2']
+      await expect(command.init()).rejects.toThrow(`Valid options: ${AVAILABLE_REGIONS.prod.join(', ')}`)
+
+      delete process.env.AIO_CLI_ENV
+      command.argv = ['--region', 'amer2']
+      await expect(command.init()).rejects.toThrow(`Valid options: ${AVAILABLE_REGIONS.prod.join(', ')}`)
+    } finally {
+      process.env.AIO_CLI_ENV = env
+    }
   })
 
   test('initialization with custom endpoint', async () => {
@@ -157,11 +208,6 @@ describe('initializeDBClient', () => {
     await expect(command.initializeDBClient()).rejects.toThrow('Failed to initialize database client: Connection failed')
 
     expect(command.debugLogger.error).toHaveBeenCalledWith('Failed to initialize DB client:', 'Connection failed')
-  })
-
-  test('init fails with invalid region', async () => {
-    command.argv = ['--region', 'invalid-region']
-    await expect(command.init()).rejects.toThrow(`to be one of: ${AVAILABLE_REGIONS.join(', ')}`)
   })
 })
 

--- a/test/commands/app/db/provision.test.js
+++ b/test/commands/app/db/provision.test.js
@@ -13,7 +13,7 @@ import { Provision } from '../../../../src/commands/app/db/provision.js'
 import { expect, jest } from '@jest/globals'
 import { stdout, stderr } from 'stdout-stderr'
 import { DBBaseCommand } from '../../../../src/DBBaseCommand.js'
-import { DB_STATUS, AVAILABLE_REGIONS } from '../../../../src/constants/db.js'
+import { DB_STATUS } from '../../../../src/constants/db.js'
 
 // Use the global DB mock
 const mockProvisionStatus = global.mockDBInstance.provisionStatus
@@ -35,7 +35,6 @@ describe('prototype', () => {
   test('flags', () => {
     const expectedFlags = Object.keys(DBBaseCommand.flags).sort()
     expect(Object.keys(Provision.flags).sort()).toEqual(expectedFlags)
-    expect(Provision.flags.region.options).toEqual(AVAILABLE_REGIONS)
     expect(Provision.enableJsonFlag).toEqual(true)
   })
 })

--- a/test/jest.env.js
+++ b/test/jest.env.js
@@ -12,3 +12,4 @@ governing permissions and limitations under the License.
 
 // Set NODE_ENV to test for all Jest tests
 process.env.NODE_ENV = 'test'
+process.env.AIO_CLI_ENV = 'test'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Validate input for the `region` flag/config option against the current cli environment.

See also:
* https://git.corp.adobe.com/CNA/adp-storage-database-deploy/pull/45
* https://github.com/adobe/aio-lib-db/pull/35

<!--- Describe your changes in detail -->

## Related Issue

[CEXT-5293: Normalize ABDB service urls in Stage](https://jira.corp.adobe.com/browse/CEXT-5293)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Available regions for `aio-lib-db` are different in stage than prod, so the input needs to be validated against the current CLI environment.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit and manual tests

## Screenshots (if appropriate):

* Proof of functionality:
<img width="703" height="370" alt="image" src="https://github.com/user-attachments/assets/65911237-5470-4041-9d46-095f8cf9b657" />


* Proof of passing tests:
<img width="697" height="811" alt="image" src="https://github.com/user-attachments/assets/542013b8-df2c-4400-9077-756a006bee23" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
