### PR TITLE
chore: update GitHub Actions workflows to Node 24

### DIFF
--- a/.github/workflows/on-push-publish-to-npm.yml
+++ b/.github/workflows/on-push-publish-to-npm.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
       - run: npm install
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,7 +34,7 @@ jobs:
           git config user.email github-actions@github.com
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: |
           npm install
           npm test


### PR DESCRIPTION
## Summary
- Updates `on-push-publish-to-npm.yml`: `actions/setup-node@v1` → `@v4`, Node 18 → 24
- Updates `prerelease.yml`: Node 22 → 24

## Test plan
- [x] Verify CI passes on this PR
- [ ] Confirm Node 24 is used in workflow run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)