### PR TITLE
fix: upgrade @inquirer/prompts to ^8 to resolve CVE-2025-54798

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@adobe/aio-lib-env": "^3.0.1",
     "@adobe/aio-lib-ims": "^8.0.0",
     "@adobe/aio-lib-state": "^5.3.0",
-    "@inquirer/prompts": "^5",
+    "@inquirer/prompts": "^8",
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
     "@oclif/table": "^0.5.0",
@@ -86,6 +86,9 @@
     "e2e": "node --experimental-vm-modules node_modules/jest/bin/jest.js --collectCoverage=false --testRegex 'e2e/e2e.js'"
   },
   "jest": {
+    "moduleNameMapper": {
+      "^@oclif/table$": "<rootDir>/test/__mocks__/oclif-table.js"
+    },
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {

--- a/test/__mocks__/oclif-table.js
+++ b/test/__mocks__/oclif-table.js
@@ -1,0 +1,1 @@
+export const makeTable = ({ data }) => data.map(row => Object.entries(row).map(([k, v]) => `${k}: ${v}`).join('\n')).join('\n')


### PR DESCRIPTION
## Summary

- Bumps `@inquirer/prompts` from `^5` to `^8`, removing the `tmp <=0.2.3` transitive dependency chain that carries **CVE-2025-54798** (GHSA-52f5-9888-hmc6): arbitrary temp file/dir write via symlink in the `dir` parameter (CVSS 2.5 Low)
- Adds `moduleNameMapper` in Jest config + `test/__mocks__/oclif-table.js` to fix a pre-existing `list.test.js` suite failure caused by `string-width@8.x` using the `/v` regex flag, which Jest 29's VM module sandbox cannot parse

## Vulnerability chain resolved

```
tmp <=0.2.3  (CVE-2025-54798)
  └── external-editor
        └── @inquirer/editor <=4.2.15
              └── @inquirer/prompts <=6.0.1  ← was ^5, now ^8
```

`@inquirer/prompts@8` dropped `@inquirer/editor` entirely, removing the whole chain. `npm audit` reports 0 vulnerabilities after this change.

## Compatibility

Only `input` and `confirm` are used in this codebase — both call signatures are unchanged through v6, v7, and v8. The project already has `"type": "module"` and `engines: ">=20.0.0"`, satisfying v8's requirements.

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] 471/471 tests pass (32/32 suites), including the previously failing `list.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)